### PR TITLE
Add prefixes dynamically

### DIFF
--- a/backend/src/common/database.ts
+++ b/backend/src/common/database.ts
@@ -1,23 +1,47 @@
 import { Prefix } from '@innotrade/enapso-graphdb-client';
 import { OntologyEntity, Record, Ontology } from '../types/types';
 
-export const parseIRI = (id: string): string => {
+export const parseNameFromClassId = (id: string): string => {
   const regex = /^[^_]*#/;
   const name = id.replace(regex, '');
   if (!name || name === id) return '';
   return name;
 };
 
-export const mapIdToOntologyEntity = (id: string): OntologyEntity => ({
-  name: parseIRI(id),
-  id,
-});
+export const parsePrefixFromClassId = (id: string): Prefix | null => {
+  const prefixRegex = /(?<=\/)([^/]*)(?=#)/;
+  const prefixMatches = id.match(prefixRegex);
+  if (!prefixMatches || !prefixMatches[0]) return null;
+
+  const iriRegex = /^[^_]*#/;
+  const iriMatches = id.match(iriRegex);
+  if (!iriMatches || !iriMatches[0]) return null;
+
+  return {
+    prefix: prefixMatches[0],
+    iri: iriMatches[0],
+  };
+};
+
+export const mapIdToOntologyEntity = (id: string): OntologyEntity | null => {
+  const prefix = parsePrefixFromClassId(id);
+  const name = parseNameFromClassId(id);
+  if (!prefix || !name) return null;
+  return {
+    prefix,
+    name,
+    id,
+  };
+};
 
 export const mapRecordToOntology = (record: Record): Ontology => ({
   Subject: record.Subject ? mapIdToOntologyEntity(record.Subject) : null,
   Object: record.Object ? mapIdToOntologyEntity(record.Object) : null,
   Predicate: mapIdToOntologyEntity(record.Predicate),
 });
+
+export const parseOntologyEntityToQuery = (entity: OntologyEntity): string =>
+  `${entity.prefix.prefix}:${entity.name}`;
 
 export const parsePrefixesToQuery = (...prefixes: Prefix[]): string => {
   const strings = prefixes.map((p) => `PREFIX ${p.prefix}: <${p.iri}>`);

--- a/backend/src/common/database.ts
+++ b/backend/src/common/database.ts
@@ -1,3 +1,4 @@
+import { Prefix } from '@innotrade/enapso-graphdb-client';
 import { OntologyEntity, Record, Ontology } from '../types/types';
 
 export const parseIRI = (id: string): string => {
@@ -17,3 +18,8 @@ export const mapRecordToOntology = (record: Record): Ontology => ({
   Object: record.Object ? mapIdToOntologyEntity(record.Object) : null,
   Predicate: mapIdToOntologyEntity(record.Predicate),
 });
+
+export const parsePrefixesToQuery = (...prefixes: Prefix[]): string => {
+  const strings = prefixes.map((p) => `PREFIX ${p.prefix}: <${p.iri}>`);
+  return strings.join('\n');
+};

--- a/backend/src/common/database.ts
+++ b/backend/src/common/database.ts
@@ -2,7 +2,9 @@ import { OntologyEntity, Record, Ontology } from '../types/types';
 
 export const parseIRI = (id: string): string => {
   const regex = /^[^_]*#/;
-  return id.replace(regex, '');
+  const name = id.replace(regex, '');
+  if (!name || name === id) return '';
+  return name;
 };
 
 export const mapIdToOntologyEntity = (id: string): OntologyEntity => ({

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,21 +1,11 @@
 import dotenv from 'dotenv-safe';
-import { EnapsoGraphDBClient } from '@innotrade/enapso-graphdb-client';
 
 dotenv.config();
 
 const PORT = process.env.PORT || 3001;
 
-const DEFAULT_PREFIXES = [
-  EnapsoGraphDBClient.PREFIX_OWL,
-  EnapsoGraphDBClient.PREFIX_RDF,
-  EnapsoGraphDBClient.PREFIX_RDFS,
-  EnapsoGraphDBClient.PREFIX_XSD,
-  EnapsoGraphDBClient.PREFIX_PROTONS,
-];
-
 export default {
   PORT,
-  DEFAULT_PREFIXES,
   GRAPHDB_BASE_URL: process.env.GRAPHDB_BASE_URL,
   GRAPHDB_REPOSITORY: process.env.GRAPHDB_REPOSITORY,
   GRAPHDB_USERNAME: process.env.GRAPHDB_USERNAME,

--- a/backend/src/database/getRelations.ts
+++ b/backend/src/database/getRelations.ts
@@ -29,8 +29,8 @@ const removeDuplicates = (ontologies: Array<Ontology>): Array<Ontology> => {
   });
 };
 
-export default async (className: string): Promise<Array<Ontology>> => {
-  const query = getRelations(className);
+export default async (classId: string): Promise<Array<Ontology>> => {
+  const query = getRelations(classId);
   const response = await DB.query(query, { transform: 'toJSON' });
   const ontologies = response.records.map(mapRecordToOntology).filter(isRelevantOntology);
   return removeDuplicates(ontologies);

--- a/backend/src/database/getSubclasses.ts
+++ b/backend/src/database/getSubclasses.ts
@@ -1,0 +1,12 @@
+import DB from './index';
+import { OntologyEntity } from '../types/types';
+import getSubclasses from './queries/getSubclasses';
+import { mapIdToOntologyEntity } from '../common/database';
+
+export default async (classId: string): Promise<Array<OntologyEntity>> => {
+  const query = getSubclasses(classId);
+  const response = await DB.query(query, { transform: 'toJSON' });
+  return response.records.map((rec) => ({
+    SubClass: mapIdToOntologyEntity(rec.directSub),
+  }));
+};

--- a/backend/src/database/index.ts
+++ b/backend/src/database/index.ts
@@ -1,6 +1,14 @@
 import { EnapsoGraphDBClient, EndpointOptions } from '@innotrade/enapso-graphdb-client';
 import config from '../config';
 
+export const PREFIXES = {
+  OWL: EnapsoGraphDBClient.PREFIX_OWL,
+  RDF: EnapsoGraphDBClient.PREFIX_RDF,
+  RDFS: EnapsoGraphDBClient.PREFIX_RDFS,
+  XSD: EnapsoGraphDBClient.PREFIX_XSD,
+  PROTONS: EnapsoGraphDBClient.PREFIX_PROTONS,
+};
+
 export default new EnapsoGraphDBClient.Endpoint({
   baseURL: config.GRAPHDB_BASE_URL,
   repository: config.GRAPHDB_REPOSITORY,

--- a/backend/src/database/index.ts
+++ b/backend/src/database/index.ts
@@ -4,5 +4,4 @@ import config from '../config';
 export default new EnapsoGraphDBClient.Endpoint({
   baseURL: config.GRAPHDB_BASE_URL,
   repository: config.GRAPHDB_REPOSITORY,
-  prefixes: config.DEFAULT_PREFIXES,
 } as EndpointOptions);

--- a/backend/src/database/queries/getRelations.ts
+++ b/backend/src/database/queries/getRelations.ts
@@ -1,12 +1,26 @@
-export default (className: string): string => `
-  PREFIX : <http://www.w3.org/TR/2003/PR-owl-guide-20031209/wine#>
+import {
+  mapIdToOntologyEntity,
+  parseOntologyEntityToQuery,
+  parsePrefixesToQuery,
+} from '../../common/database';
+
+export default (classId: string): string => {
+  const node = mapIdToOntologyEntity(classId);
+  if (!node) return '';
+
+  const fullClassName = parseOntologyEntityToQuery(node);
+  const prefixString = parsePrefixesToQuery(node.prefix);
+
+  return `
+  ${prefixString}
   SELECT *
   WHERE {
     {
-      ${className} ?Predicate ?Object
+      ${fullClassName} ?Predicate ?Object
     }
     UNION
     {
-      ?Subject ?Predicate ${className}
+      ?Subject ?Predicate ${fullClassName}
     }
   }`;
+};

--- a/backend/src/database/queries/getSubclasses.ts
+++ b/backend/src/database/queries/getSubclasses.ts
@@ -1,0 +1,26 @@
+import {
+  mapIdToOntologyEntity,
+  parseOntologyEntityToQuery,
+  parsePrefixesToQuery,
+} from '../../common/database';
+import { PREFIXES } from '../index';
+
+export default (classId: string): string => {
+  const node = mapIdToOntologyEntity(classId);
+  if (!node) return '';
+
+  const fullClassName = parseOntologyEntityToQuery(node);
+  const prefixString = parsePrefixesToQuery(node.prefix, PREFIXES.RDFS);
+
+  return `
+  ${prefixString}
+  SELECT *
+  WHERE { 
+    ?directSub rdfs:subClassOf ${fullClassName} .
+    FILTER NOT EXISTS { 
+      ?otherSub rdfs:subClassOf ${fullClassName} . 
+      ?directSub rdfs:subClassOf ?otherSub .
+      FILTER (?otherSub != ?directSub)
+    }
+  }`;
+};

--- a/backend/src/routes/ontologies.ts
+++ b/backend/src/routes/ontologies.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import getSubclasses from '../database/getSubclasses';
 import getRelations from '../database/getRelations';
 
 const router = Router();
@@ -14,6 +15,18 @@ const getRelationsFromClass = async (req, res) => {
   }
 };
 
+const getSubclassesFromClass = async (req, res) => {
+  try {
+    const data = await getSubclasses(req.params.classId);
+    res.json(data);
+  } catch (e) {
+    console.log(e);
+    res.status(500);
+    res.json({ message: e.message });
+  }
+};
+
 router.get('/relations/:classId', getRelationsFromClass);
+router.get('/subclasses/:classId', getSubclassesFromClass);
 
 export default router;

--- a/backend/src/routes/ontologies.ts
+++ b/backend/src/routes/ontologies.ts
@@ -5,7 +5,7 @@ const router = Router();
 
 const getRelationsFromClass = async (req, res) => {
   try {
-    const data = await getRelations(req.params.className);
+    const data = await getRelations(req.params.classId);
     res.json(data);
   } catch (e) {
     console.log(e);
@@ -14,6 +14,6 @@ const getRelationsFromClass = async (req, res) => {
   }
 };
 
-router.get('/:className', getRelationsFromClass);
+router.get('/relations/:classId', getRelationsFromClass);
 
 export default router;

--- a/backend/src/types/types.ts
+++ b/backend/src/types/types.ts
@@ -1,4 +1,7 @@
+import { Prefix } from '@innotrade/enapso-graphdb-client';
+
 export type OntologyEntity = {
+  prefix: Prefix;
   id: string;
   name: string;
 };

--- a/backend/src/types/types.ts
+++ b/backend/src/types/types.ts
@@ -13,7 +13,7 @@ export interface Edge extends OntologyEntity {}
 export type Ontology = {
   Subject: Node | null;
   Object: Node | null;
-  Predicate: Edge;
+  Predicate: Edge | null;
 };
 
 export type Record = {

--- a/frontend/src/api/ontologies.ts
+++ b/frontend/src/api/ontologies.ts
@@ -1,5 +1,5 @@
 import api from './api';
 
 // eslint-disable-next-line import/prefer-default-export
-export const getRelations = (className: string): Promise<any> =>
-  api.GET(`/ontologies/%3A${className}`);
+export const getRelations = (classId: string): Promise<any> =>
+  api.GET(`ontologies/relations/${encodeURIComponent(classId)}`);

--- a/frontend/src/components/OntologyTable.tsx
+++ b/frontend/src/components/OntologyTable.tsx
@@ -41,7 +41,7 @@ const OntologyTable: React.FC = () => {
 
   const clickNode = async (node: Node) => {
     setSelectedNode(node);
-    const newOntologies = await getRelations(node.name);
+    const newOntologies = await getRelations(node.id);
     setOntologies(newOntologies);
   };
 

--- a/frontend/src/components/OntologyTable.tsx
+++ b/frontend/src/components/OntologyTable.tsx
@@ -3,6 +3,10 @@ import { getRelations } from '../api/ontologies';
 import { Node, Ontology } from '../types';
 
 const initialNode: Node = {
+  prefix: {
+    prefix: 'wine',
+    iri: 'http://www.w3.org/TR/2003/PR-owl-guide-20031209/wine#',
+  },
   name: 'FormanChardonnay',
   id: 'http://www.w3.org/TR/2003/PR-owl-guide-20031209/wine#FormanChardonnay',
 };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,14 +1,21 @@
 export type Node = {
   id: string;
   name: string;
+  prefix: Prefix;
 };
 
 export type Edge = {
   id: string;
   name: string;
 };
+
 export type Ontology = {
   Subject: Node | null;
   Object: Node | null;
   Predicate: Edge;
+};
+
+export type Prefix = {
+  prefix: string;
+  iri: string;
 };


### PR DESCRIPTION
Prefixes, i.e. namespaces, are now added to the queries dynamically. I added a function in common/database which parses a prefix object to a string which can be prepended to the query. See the existing queries for examples. 

I also added prefix as a field in OntologyEntity so that the frontend can use it. Instead of using the parsed prefix and class name in the URL the frontend now queries the backend using classIds (IRIs). This can easily be mapped to an OntologyEntity in the backend. 

Lastly I added an endpoint to retrieve all subclasses of a given class. This should probably have been its own issue and PR but it was easier like this :stuck_out_tongue: 