### PR TITLE
Fix forceSim type definition

### DIFF
--- a/frontend/src/components/Graph.tsx
+++ b/frontend/src/components/Graph.tsx
@@ -29,9 +29,7 @@ const Graph: React.FC = () => {
   const svgref = useRef<SVGSVGElement>(null);
   const [nodes, setNodes] = useState<GraphNode[]>([]);
   const [links, setLinks] = useState<GraphEdge[]>([]);
-  const [forceSim, setForceSim] = useState<Simulation<GraphNode, GraphEdge>>(
-    (undefined as unknown) as Simulation<GraphNode, GraphEdge>,
-  );
+  const [forceSim, setForceSim] = useState<Simulation<GraphNode, GraphEdge>>();
 
   const loadInitialData = async () => {
     const ontologies: Ontology[] = await getRelations(initialNode.id);


### PR DESCRIPTION
Closes #44 

I think this is a better way to do it. Our problem was we tried to set it as null which didn't work because null and undefined are different because JavaScript is dumb. This implicitly initializes the value as undefined, i.e. the inferred type is _Simulation<GraphNode, GraphEdge> | undefined_. 