### PR TITLE
Fix unlock all nodes not restarting force simulation

### DIFF
--- a/frontend/src/d3/GraphSimulation.ts
+++ b/frontend/src/d3/GraphSimulation.ts
@@ -410,10 +410,10 @@ export default class {
       .data(this.nodes)
       .each(function (node) {
         const nodeContainer = d3.select(this).node() as SVGGElement;
-        unlockNode(nodeContainer, node, false);
         if (node.isLocked) {
           hasUpdatedNode = true;
         }
+        unlockNode(nodeContainer, node, false);
       });
     if (hasUpdatedNode) {
       this.forceSimulation.alpha(0.5);


### PR DESCRIPTION
Fixes a minor bug in #210 causing unlock all nodes button to not restart the D3 simulation. 